### PR TITLE
do not cache redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <title>Redirecting to http://www.microsoft.com/openness/</title>
     <meta http-equiv="refresh" content="5; url=http://www.microsoft.com/openness/">
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
     <script type="text/javascript">
         window.location.replace("http://www.microsoft.com/openness/");
     </script>


### PR DESCRIPTION
Tell browsers not to cache the redirect incase microsoft decides to change the redirect in the future.
reference: http://stackoverflow.com/questions/1341089/using-meta-tags-to-turn-off-caching-in-all-browsers
