### PR TITLE
Fixes #30 (various layout changes for small screen widths)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,7 @@
 .center {
     margin-left: auto;
     margin-right: auto;
+    text-align: center;
 }
 
 .featured-projects {
@@ -87,10 +88,12 @@
 }
 
 .all-projects .row .panel .fork-info {
+    font-size: 14px;
     overflow:hidden;
     -ms-text-overflow:ellipsis;
     text-overflow:ellipsis;
-    height: 40px;
+    height: 26px;
+    padding: 5px 10px 5px 10px;
 }
 
 .glyphicon {

--- a/index-new.html
+++ b/index-new.html
@@ -108,7 +108,7 @@
                                     <div class="panel-body description">{{project.Description}}</div>
                                     <div class="panel-body">
                                         <div class="row">
-                                            <div class="col-sm-8 col-sm-offset-4 text-right">
+                                            <div class="col-sm-8 col-sm-offset-4 col-xs-12 col-xs-offset-0 text-right">
                                                 <span class="span-stars-group">
                                                     {{project.Stars}}
                                                     <span class="glyphicon glyphicon-star"></span>
@@ -139,7 +139,7 @@
                     <h3>All Repos</h3>
                     <div class="loading" ng-hide="main.projects">Loading data...</div>
                     <div class="row" ng-show="main.projects">
-                        <div class="col-sm-4 col-sm-offset-0" ng-repeat="project in filtered | startFrom:(currentPage-1)*entryLimit | limitTo:entryLimit">
+                        <div class="col-md-4 col-md-offset-0 col-xs-6 col-xs-offset-0" ng-repeat="project in filtered | startFrom:(currentPage-1)*entryLimit | limitTo:entryLimit">
                             <div class="panel panel-default">
                                     <div class="panel-heading">
                                         <a ng-href="{{project.Url}}">
@@ -154,7 +154,7 @@
                                 <div class="panel-body description"><span>{{project.Description}}</span></div>
                                 <div class="panel-body">
                                     <div class="row">
-                                        <div class="col-sm-10 col-sm-offset-1">
+                                        <div class="center">
                                             <span class="span-stars-group">{{project.Stars}}<span class="glyphicon glyphicon-star"></span>stars</span>
                                             <span class="span-forks-group">{{project.Forks}}<span class="glyphicon glyphicon-random"></span>forks</span>
                                         </div>
@@ -163,7 +163,7 @@
                             </div>
                         </div>
                         <div>
-                            <pagination class="col-sm-12 paginator" data-boundary-links="true" data-num-pages="noOfPages" data-current-page="currentPage" max-size="maxSize" class="pagination-small" data-previous-text="&laquo;"
+                            <pagination class="col-xs-12 paginator" data-boundary-links="true" data-num-pages="noOfPages" data-current-page="currentPage" max-size="maxSize" class="pagination-small" data-previous-text="&laquo;"
                                 data-next-text="&raquo;"></pagination>
                         </div>
                     </div>
@@ -172,7 +172,7 @@
                 <div class="organizations">
                     <h3 class="orgs-heading">Other Microsoft GitHub Organizations</h3>
                     <div class="row">
-                        <div class="col-sm-3" ng-repeat="org in main.orgs">
+                        <div class="col-md-3 col-xs-6" ng-repeat="org in main.orgs">
                             <a ng-href="{{org.url}}" class="orglink">
                                 <!-- <img ng-src="{{org.image}}" alt="{{org.image}}"> -->
                                     <span class="text-center">{{org.title}}</span>


### PR DESCRIPTION
As you decrease screen width, we will reduce the number of columns of tiles and org links to 2. It should look decent on mobile screens. The "stars" and "forks" will remain in the center. Things will look bad only if you try to go much below typical mobile screen width.
Also made the "forked from" area a little smaller by reducing font and padding etc.
