### PR TITLE
Correct font fallbacks

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,7 +1,7 @@
 ﻿body {
     /*padding-top: 50px;*/
     /*padding-bottom: 20px;*/
-    font-family:Segoe UI;
+    font-family:wf_segoe-ui_normal,"Segoe UI",Segoe,"Segoe WP",Tahoma,Verdana,Arial,sans-serif;
 }
 
 /* Set padding to keep content from hitting the edges */


### PR DESCRIPTION
Fonts were incorrect, showing as serif.

Before:

![image](https://cloud.githubusercontent.com/assets/510740/5016132/8d8803b4-6a9b-11e4-9e45-0bf7887b020b.png)

After:

![image](https://cloud.githubusercontent.com/assets/510740/5016145/a76873d6-6a9b-11e4-801b-6487823132c7.png)
