### PR TITLE
Moved the glyphs for repo stars and forks to the left side of the text for improved readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,14 +108,10 @@
                                         <div class="row">
                                             <div class="col-sm-8 col-sm-offset-4 col-xs-12 col-xs-offset-0 text-right">
                                                 <span class="span-stars-group">
-                                                    {{project.Stars}}
-                                                    <span class="glyphicon glyphicon-star"></span>
-                                                    stars
+                                                    <span class="glyphicon glyphicon-star"></span>{{project.Stars}} stars
                                                 </span>
                                                 <span class="span-forks-group">
-                                                    {{project.Forks}}
-                                                    <span class="glyphicon glyphicon-random"></span>
-                                                    forks
+                                                    <span class="glyphicon glyphicon-random"></span>{{project.Forks}} forks
                                                 </span>
                                             </div>
                                         </div>
@@ -153,8 +149,8 @@
                                 <div class="panel-body">
                                     <div class="row">
                                         <div class="center">
-                                            <span class="span-stars-group">{{project.Stars}}<span class="glyphicon glyphicon-star"></span>stars</span>
-                                            <span class="span-forks-group">{{project.Forks}}<span class="glyphicon glyphicon-random"></span>forks</span>
+                                            <span class="glyphicon glyphicon-star"></span>{{project.Stars}} stars
+                                            <span class="glyphicon glyphicon-random"></span>{{project.Forks}} forks
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Reading the number of stars and forks a repo has is kind of awkward with the glyph in the middle. This PR moves them to the left as below, which is a bit cleaner and separates the stars from the forks better:

![glyphs](https://cloud.githubusercontent.com/assets/1686802/5023468/fbc1010c-6ac6-11e4-8ac6-8fb49f8e27d8.png)
