### PR TITLE
fixing Azure-Samples link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ List of Microsoft Organizations on GitHub
 -  https://github.com/OSTC 
 -  https://github.com/Reactive-Extensions
 -  https://github.com/SignalR
--  https://github.com/WindowsAzure-Samples
+-  https://github.com/Azure-Samples
 -  https://github.com/winjs
 -  https://github.com/yammer
 


### PR DESCRIPTION
currently goes to a 404 page (referenced in issue #81) 
https://github.com/WindowsAzure-Samples >> https://github.com/Azure-Samples

(see link towards bottom of https://github.com/Microsoft/microsoft.github.io)
