### PR TITLE
Add Microsoft Translator to lists of Microsoft GitHub Organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of Microsoft Organizations on GitHub
 -  https://github.com/microsoft-hsg
 -  https://github.com/MicrosoftHPC
 -  https://github.com/MicrosoftResearch
+-  https://github.com/MicrosoftTranslator
 -  https://github.com/MSOpenTech
 -  https://github.com/ms-iot
 -  https://github.com/mspnp

--- a/data/organization.json
+++ b/data/organization.json
@@ -183,4 +183,9 @@
      "name": "OData", 
      "url": "https://github.com/OData", 
      "image": "https://avatars0.githubusercontent.com/u/916520?v=3&s=200" 
-}] 
+}, {
+    "title": "Microsoft Translator",
+    "name": "MicrosoftTranslator",
+    "url": "https://github.com/MicrosoftTranslator",
+    "image": "https://avatars3.githubusercontent.com/u/11097237?v=3&s=200"
+}]


### PR DESCRIPTION
Closes Microsoft/microsoft.github.io#131.
Tested using [GitHub Pages branch](https://0xfeeddeadbeef.github.io/microsoft.github.io/).
