### PR TITLE
Redirect https://microsoft.github.io/reverse-proxy

### DIFF
--- a/reverse-proxy/index.html
+++ b/reverse-proxy/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://aka.ms/YarpDocumentation" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://aka.ms/YarpDocumentation';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://aka.ms/YarpDocumentation">https://aka.ms/YarpDocumentation</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Hi,

We moved our repo from microsoft/reverse-proxy to dotnet/yarp, breaking our docs in the process.

This PR would allow users that still have a reference to the old doc website to be redirected to the new one. Eventually we might want to be able to redirect all of our old doc pages, but for now just the root folder will do.

Old uri: https://microsoft.github.io/reverse-proxy
New uri: https://dotnet.github.io/yarp

We chose to use an aka.ms alias to avoid having to change this again when/if we move our docs to the official MS docs.

Related issue: https://github.com/dotnet/yarp/issues/2737
