### PR TITLE
Redirect all YARP articles

### DIFF
--- a/reverse-proxy/api/index.html
+++ b/reverse-proxy/api/index.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/api/index.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/api/index.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/api/index.html">https://dotnet.github.io/yarp/api/index.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/ab-testing.html
+++ b/reverse-proxy/articles/ab-testing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/ab-testing.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/ab-testing.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/ab-testing.html">https://dotnet.github.io/yarp/articles/ab-testing.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/authn-authz.html
+++ b/reverse-proxy/articles/authn-authz.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/authn-authz.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/authn-authz.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/authn-authz.html">https://dotnet.github.io/yarp/articles/authn-authz.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-files.html
+++ b/reverse-proxy/articles/config-files.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-files.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/config-files.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-files.html">https://dotnet.github.io/yarp/articles/config-files.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-filters.html
+++ b/reverse-proxy/articles/config-filters.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-filters.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/config-filters.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-filters.html">https://dotnet.github.io/yarp/articles/config-filters.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-providers.html
+++ b/reverse-proxy/articles/config-providers.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-providers.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/config-providers.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-providers.html">https://dotnet.github.io/yarp/articles/config-providers.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/cors.html
+++ b/reverse-proxy/articles/cors.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/cors.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/cors.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/cors.html">https://dotnet.github.io/yarp/articles/cors.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/destination-resolvers.html
+++ b/reverse-proxy/articles/destination-resolvers.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/destination-resolvers.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/destination-resolvers.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/destination-resolvers.html">https://dotnet.github.io/yarp/articles/destination-resolvers.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/dests-health-checks.html
+++ b/reverse-proxy/articles/dests-health-checks.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/dests-health-checks.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/dests-health-checks.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/dests-health-checks.html">https://dotnet.github.io/yarp/articles/dests-health-checks.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/diagnosing-yarp-issues.html
+++ b/reverse-proxy/articles/diagnosing-yarp-issues.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html">https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/direct-forwarding.html
+++ b/reverse-proxy/articles/direct-forwarding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/direct-forwarding.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/direct-forwarding.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/direct-forwarding.html">https://dotnet.github.io/yarp/articles/direct-forwarding.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/distributed-tracing.html
+++ b/reverse-proxy/articles/distributed-tracing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/distributed-tracing.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/distributed-tracing.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/distributed-tracing.html">https://dotnet.github.io/yarp/articles/distributed-tracing.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/getting-started.html
+++ b/reverse-proxy/articles/getting-started.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/getting-started.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/getting-started.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/getting-started.html">https://dotnet.github.io/yarp/articles/getting-started.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/grpc.html
+++ b/reverse-proxy/articles/grpc.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/grpc.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/grpc.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/grpc.html">https://dotnet.github.io/yarp/articles/grpc.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/header-guidelines.html
+++ b/reverse-proxy/articles/header-guidelines.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/header-guidelines.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/header-guidelines.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/header-guidelines.html">https://dotnet.github.io/yarp/articles/header-guidelines.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/header-routing.html
+++ b/reverse-proxy/articles/header-routing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/header-routing.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/header-routing.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/header-routing.html">https://dotnet.github.io/yarp/articles/header-routing.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/http-client-config.html
+++ b/reverse-proxy/articles/http-client-config.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/http-client-config.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/http-client-config.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/http-client-config.html">https://dotnet.github.io/yarp/articles/http-client-config.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/http3.html
+++ b/reverse-proxy/articles/http3.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/http3.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/http3.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/http3.html">https://dotnet.github.io/yarp/articles/http3.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/https-tls.html
+++ b/reverse-proxy/articles/https-tls.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/https-tls.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/https-tls.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/https-tls.html">https://dotnet.github.io/yarp/articles/https-tls.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/httpsys-delegation.html
+++ b/reverse-proxy/articles/httpsys-delegation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/httpsys-delegation.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/httpsys-delegation.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/httpsys-delegation.html">https://dotnet.github.io/yarp/articles/httpsys-delegation.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/index.html
+++ b/reverse-proxy/articles/index.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/index.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/index.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/index.html">https://dotnet.github.io/yarp/articles/index.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/lets-encrypt.html
+++ b/reverse-proxy/articles/lets-encrypt.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/lets-encrypt.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/lets-encrypt.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/lets-encrypt.html">https://dotnet.github.io/yarp/articles/lets-encrypt.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/load-balancing.html
+++ b/reverse-proxy/articles/load-balancing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/load-balancing.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/load-balancing.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/load-balancing.html">https://dotnet.github.io/yarp/articles/load-balancing.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/middleware.html
+++ b/reverse-proxy/articles/middleware.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/middleware.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/middleware.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/middleware.html">https://dotnet.github.io/yarp/articles/middleware.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/output-caching.html
+++ b/reverse-proxy/articles/output-caching.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/output-caching.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/output-caching.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/output-caching.html">https://dotnet.github.io/yarp/articles/output-caching.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/packages-refs.html
+++ b/reverse-proxy/articles/packages-refs.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/packages-refs.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/packages-refs.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/packages-refs.html">https://dotnet.github.io/yarp/articles/packages-refs.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/queryparameter-routing.html
+++ b/reverse-proxy/articles/queryparameter-routing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/queryparameter-routing.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/queryparameter-routing.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/queryparameter-routing.html">https://dotnet.github.io/yarp/articles/queryparameter-routing.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/rate-limiting.html
+++ b/reverse-proxy/articles/rate-limiting.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/rate-limiting.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/rate-limiting.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/rate-limiting.html">https://dotnet.github.io/yarp/articles/rate-limiting.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/runtimes.html
+++ b/reverse-proxy/articles/runtimes.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/runtimes.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/runtimes.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/runtimes.html">https://dotnet.github.io/yarp/articles/runtimes.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/service-fabric-int.html
+++ b/reverse-proxy/articles/service-fabric-int.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/service-fabric-int.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/service-fabric-int.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/service-fabric-int.html">https://dotnet.github.io/yarp/articles/service-fabric-int.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/session-affinity.html
+++ b/reverse-proxy/articles/session-affinity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YARP Documentation</title>
+    <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/session-affinity.html" />
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      location.href = 'https://dotnet.github.io/yarp/articles/session-affinity.html';
+    </script>
+  </head>
+  <body>
+    <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/session-affinity.html">https://dotnet.github.io/yarp/articles/session-affinity.html</a>.
+    </p>
+  </body>
+</html>

--- a/reverse-proxy/articles/timeouts.html
+++ b/reverse-proxy/articles/timeouts.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/timeouts.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/timeouts.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/timeouts.html">https://dotnet.github.io/yarp/articles/timeouts.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/transforms.html
+++ b/reverse-proxy/articles/transforms.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/transforms.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/transforms.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/transforms.html">https://dotnet.github.io/yarp/articles/transforms.html</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/websockets.html
+++ b/reverse-proxy/articles/websockets.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/websockets.html" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://dotnet.github.io/yarp/articles/websockets.html';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/websockets.html">https://dotnet.github.io/yarp/articles/websockets.html</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
Redirect all YARP articles as well.
I added a redirect for the base `/api/index.html` page, didn't bother with the rest since they're not useful anyway.

Generated via https://gist.github.com/MihaZupan/b20df86edb234a3f5c11dfdaf57e9300