### PR TITLE
Redirect YARP docs to learn.microsoft.com

### DIFF
--- a/reverse-proxy/api/index.html
+++ b/reverse-proxy/api/index.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/api/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20API%20Reference&category=Reference" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/api/index.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20API%20Reference&category=Reference';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/api/index.html">https://dotnet.github.io/yarp/api/index.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20API%20Reference&category=Reference">https://learn.microsoft.com/search/?terms=YARP%20API%20Reference&category=Reference</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/ab-testing.html
+++ b/reverse-proxy/articles/ab-testing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/ab-testing.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20A%2FB%20Testing&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/ab-testing.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20A%2FB%20Testing&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/ab-testing.html">https://dotnet.github.io/yarp/articles/ab-testing.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20A%2FB%20Testing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20A%2FB%20Testing&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/authn-authz.html
+++ b/reverse-proxy/articles/authn-authz.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/authn-authz.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Authentication%20and%20Authorization&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/authn-authz.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Authentication%20and%20Authorization&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/authn-authz.html">https://dotnet.github.io/yarp/articles/authn-authz.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Authentication%20and%20Authorization&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Authentication%20and%20Authorization&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-files.html
+++ b/reverse-proxy/articles/config-files.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Configuration&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Configuration&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Configuration&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Configuration&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-files.html
+++ b/reverse-proxy/articles/config-files.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-files.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/config-files.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-files.html">https://dotnet.github.io/yarp/articles/config-files.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Files&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-filters.html
+++ b/reverse-proxy/articles/config-filters.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-filters.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Filters&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/config-filters.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Filters&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-filters.html">https://dotnet.github.io/yarp/articles/config-filters.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Filters&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Filters&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/config-providers.html
+++ b/reverse-proxy/articles/config-providers.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/config-providers.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Providers&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/config-providers.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Providers&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/config-providers.html">https://dotnet.github.io/yarp/articles/config-providers.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Providers&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Configuration%20Providers&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/cors.html
+++ b/reverse-proxy/articles/cors.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/cors.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Cross-Origin%20Requests%20%28CORS%29&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/cors.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Cross-Origin%20Requests%20%28CORS%29&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/cors.html">https://dotnet.github.io/yarp/articles/cors.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Cross-Origin%20Requests%20%28CORS%29&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Cross-Origin%20Requests%20%28CORS%29&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/destination-resolvers.html
+++ b/reverse-proxy/articles/destination-resolvers.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/destination-resolvers.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Destination%20Resolvers&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/destination-resolvers.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Destination%20Resolvers&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/destination-resolvers.html">https://dotnet.github.io/yarp/articles/destination-resolvers.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Destination%20Resolvers&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Destination%20Resolvers&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/dests-health-checks.html
+++ b/reverse-proxy/articles/dests-health-checks.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/dests-health-checks.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Destinations%20Health%20Checks&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/dests-health-checks.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Destinations%20Health%20Checks&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/dests-health-checks.html">https://dotnet.github.io/yarp/articles/dests-health-checks.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Destinations%20Health%20Checks&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Destinations%20Health%20Checks&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/diagnosing-yarp-issues.html
+++ b/reverse-proxy/articles/diagnosing-yarp-issues.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Diagnosing%20proxy%20issues&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Diagnosing%20proxy%20issues&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html">https://dotnet.github.io/yarp/articles/diagnosing-yarp-issues.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Diagnosing%20proxy%20issues&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Diagnosing%20proxy%20issues&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/direct-forwarding.html
+++ b/reverse-proxy/articles/direct-forwarding.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/direct-forwarding.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Direct%20Forwarding&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/direct-forwarding.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Direct%20Forwarding&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/direct-forwarding.html">https://dotnet.github.io/yarp/articles/direct-forwarding.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Direct%20Forwarding&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Direct%20Forwarding&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/distributed-tracing.html
+++ b/reverse-proxy/articles/distributed-tracing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/distributed-tracing.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Distributed%20Tracing&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/distributed-tracing.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Distributed%20Tracing&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/distributed-tracing.html">https://dotnet.github.io/yarp/articles/distributed-tracing.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Distributed%20Tracing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Distributed%20Tracing&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/getting-started.html
+++ b/reverse-proxy/articles/getting-started.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/getting-started.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/getting-started.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/getting-started.html">https://dotnet.github.io/yarp/articles/getting-started.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/grpc.html
+++ b/reverse-proxy/articles/grpc.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/grpc.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20gRPC&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/grpc.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20gRPC&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/grpc.html">https://dotnet.github.io/yarp/articles/grpc.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20gRPC&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20gRPC&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/header-guidelines.html
+++ b/reverse-proxy/articles/header-guidelines.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/header-guidelines.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Header%20Guidelines&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/header-guidelines.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Header%20Guidelines&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/header-guidelines.html">https://dotnet.github.io/yarp/articles/header-guidelines.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Header%20Guidelines&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Header%20Guidelines&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/header-routing.html
+++ b/reverse-proxy/articles/header-routing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Header&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Header&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Header&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Header&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/header-routing.html
+++ b/reverse-proxy/articles/header-routing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/header-routing.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/header-routing.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/header-routing.html">https://dotnet.github.io/yarp/articles/header-routing.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Header%20Routing&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/http-client-config.html
+++ b/reverse-proxy/articles/http-client-config.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/http-client-config.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20HTTP%20client%20configuration&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/http-client-config.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20HTTP%20client%20configuration&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/http-client-config.html">https://dotnet.github.io/yarp/articles/http-client-config.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20HTTP%20client%20configuration&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20HTTP%20client%20configuration&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/http3.html
+++ b/reverse-proxy/articles/http3.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/http3.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20HTTP%2F3&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/http3.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20HTTP%2F3&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/http3.html">https://dotnet.github.io/yarp/articles/http3.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20HTTP%2F3&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20HTTP%2F3&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/https-tls.html
+++ b/reverse-proxy/articles/https-tls.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/https-tls.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20HTTPS%20%26%20TLS&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/https-tls.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20HTTPS%20%26%20TLS&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/https-tls.html">https://dotnet.github.io/yarp/articles/https-tls.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20HTTPS%20%26%20TLS&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20HTTPS%20%26%20TLS&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/httpsys-delegation.html
+++ b/reverse-proxy/articles/httpsys-delegation.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/httpsys-delegation.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Http.sys%20Delegation&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/httpsys-delegation.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Http.sys%20Delegation&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/httpsys-delegation.html">https://dotnet.github.io/yarp/articles/httpsys-delegation.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Http.sys%20Delegation&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Http.sys%20Delegation&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/index.html
+++ b/reverse-proxy/articles/index.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/index.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/index.html">https://dotnet.github.io/yarp/articles/index.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/lets-encrypt.html
+++ b/reverse-proxy/articles/lets-encrypt.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/lets-encrypt.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Lets%20Encrypt&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/lets-encrypt.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Lets%20Encrypt&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/lets-encrypt.html">https://dotnet.github.io/yarp/articles/lets-encrypt.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Lets%20Encrypt&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Lets%20Encrypt&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/load-balancing.html
+++ b/reverse-proxy/articles/load-balancing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/load-balancing.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Load%20Balancing&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/load-balancing.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Load%20Balancing&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/load-balancing.html">https://dotnet.github.io/yarp/articles/load-balancing.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Load%20Balancing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Load%20Balancing&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/middleware.html
+++ b/reverse-proxy/articles/middleware.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/middleware.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Middleware&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/middleware.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Middleware&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/middleware.html">https://dotnet.github.io/yarp/articles/middleware.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Middleware&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Middleware&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/output-caching.html
+++ b/reverse-proxy/articles/output-caching.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/output-caching.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Output%20Caching&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/output-caching.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Output%20Caching&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/output-caching.html">https://dotnet.github.io/yarp/articles/output-caching.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Output%20Caching&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Output%20Caching&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/packages-refs.html
+++ b/reverse-proxy/articles/packages-refs.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/packages-refs.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Packages%20references&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/packages-refs.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Packages%20references&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/packages-refs.html">https://dotnet.github.io/yarp/articles/packages-refs.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Packages%20references&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Packages%20references&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/queryparameter-routing.html
+++ b/reverse-proxy/articles/queryparameter-routing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/queryparameter-routing.html
+++ b/reverse-proxy/articles/queryparameter-routing.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/queryparameter-routing.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/queryparameter-routing.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/queryparameter-routing.html">https://dotnet.github.io/yarp/articles/queryparameter-routing.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Query%20Parameter%20Routing&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/rate-limiting.html
+++ b/reverse-proxy/articles/rate-limiting.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/rate-limiting.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Rate%20Limiting&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/rate-limiting.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Rate%20Limiting&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/rate-limiting.html">https://dotnet.github.io/yarp/articles/rate-limiting.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Rate%20Limiting&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Rate%20Limiting&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/runtimes.html
+++ b/reverse-proxy/articles/runtimes.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/runtimes.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Supported%20Runtimes&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/runtimes.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Supported%20Runtimes&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/runtimes.html">https://dotnet.github.io/yarp/articles/runtimes.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Supported%20Runtimes&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Supported%20Runtimes&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/service-fabric-int.html
+++ b/reverse-proxy/articles/service-fabric-int.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/service-fabric-int.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Service%20Fabric%20Integration&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/service-fabric-int.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Service%20Fabric%20Integration&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/service-fabric-int.html">https://dotnet.github.io/yarp/articles/service-fabric-int.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Service%20Fabric%20Integration&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Service%20Fabric%20Integration&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/session-affinity.html
+++ b/reverse-proxy/articles/session-affinity.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/session-affinity.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Session%20Affinity&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/session-affinity.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Session%20Affinity&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/session-affinity.html">https://dotnet.github.io/yarp/articles/session-affinity.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Session%20Affinity&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Session%20Affinity&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/timeouts.html
+++ b/reverse-proxy/articles/timeouts.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/timeouts.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Timeouts&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/timeouts.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Timeouts&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/timeouts.html">https://dotnet.github.io/yarp/articles/timeouts.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Timeouts&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Timeouts&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/transforms.html
+++ b/reverse-proxy/articles/transforms.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/transforms.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Transforms&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/transforms.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Transforms&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/transforms.html">https://dotnet.github.io/yarp/articles/transforms.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Transforms&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Transforms&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/articles/websockets.html
+++ b/reverse-proxy/articles/websockets.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/articles/websockets.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20WebSockets%20and%20SPDY&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/articles/websockets.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20WebSockets%20and%20SPDY&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/articles/websockets.html">https://dotnet.github.io/yarp/articles/websockets.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20WebSockets%20and%20SPDY&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20WebSockets%20and%20SPDY&category=Documentation</a>.
     </p>
   </body>
 </html>

--- a/reverse-proxy/index.html
+++ b/reverse-proxy/index.html
@@ -3,15 +3,15 @@
   <head>
     <title>YARP Documentation</title>
     <link rel="shortcut icon" href="//www.microsoft.com/favicon.ico?v2" />
-    <meta http-equiv="refresh" content="2;url=https://dotnet.github.io/yarp/index.html" />
+    <meta http-equiv="refresh" content="2;url=https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation" />
     <meta charset="UTF-8">
     <script type="text/javascript">
-      location.href = 'https://dotnet.github.io/yarp/index.html';
+      location.href = 'https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation';
     </script>
   </head>
   <body>
     <p style="font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;font-size:18px;text-align:center">
-      YARP documentation has been moved to <a href="https://dotnet.github.io/yarp/index.html">https://dotnet.github.io/yarp/index.html</a>.
+      YARP documentation has been moved to <a href="https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation">https://learn.microsoft.com/search/?terms=YARP%20Getting%20Started&category=Documentation</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
Should be the final change we make to these redirects now that the docs are at
https://learn.microsoft.com/aspnet/core/fundamentals/servers/yarp/getting-started